### PR TITLE
トップページの取得件数を減らす

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/src/wp-content/themes/simplicity2/functions.php
+++ b/src/wp-content/themes/simplicity2/functions.php
@@ -1308,3 +1308,10 @@ function remove_admin_bar_menu( $wp_admin_bar ) {
    
  }
 add_action( 'admin_bar_menu', 'remove_admin_bar_menu', 70 );
+
+function add_meta_query_vars( $public_query_vars ) {
+    $public_query_vars[] = 'meta_key'; //カスタムフィールドのキー
+    $public_query_vars[] = 'meta_value'; //カスタムフィールドの値（文字列）
+    return $public_query_vars;
+}
+add_filter( 'query_vars', 'add_meta_query_vars' );

--- a/src/wp-content/themes/simplicity2/list.php
+++ b/src/wp-content/themes/simplicity2/list.php
@@ -242,7 +242,7 @@ $arg = array('post_type' => 'event',
                 'compare'=> '<=', // 比較演算
             ),
         ),
-        'posts_per_page' => 50,
+        'posts_per_page' => 30,
         'paged' => $paged
     );
 $data = get_posts($arg);
@@ -330,20 +330,11 @@ if ( is_active_sidebar( 'widget-index-bottom' ) ):
   echo '</div>';
 endif; ?>
 
-<?php
-////////////////////////////
-//エントリーのページャー
-////////////////////////////
-if ( is_list_pager_type_responsive() ) {
-  //レスポンシブタイプのページャー関数の呼び出し
-  responsive_pagination();
-} else {
-  //旧タイプのページャー
-  get_template_part('pager-paginate-links');
-}
-?>
-
-
+<a href="https://support.eventz.jp/events/tag/cafekai?order=desc&meta_key=_eventorganiser_schedule_start_start&orderby=meta_value">
+<ul class="pagination">
+もっと見る
+</ul>
+</a>
 
 <div id="Externalseminar">
 <h2><img src="http://support.eventz.jp/wp-content/uploads/2017/05/icon_hoshi02-1.svg">外部セミナー</img></h2>

--- a/src/wp-content/themes/simplicity2/list.php
+++ b/src/wp-content/themes/simplicity2/list.php
@@ -330,11 +330,11 @@ if ( is_active_sidebar( 'widget-index-bottom' ) ):
   echo '</div>';
 endif; ?>
 
-<a href="https://support.eventz.jp/events/tag/cafekai?order=desc&meta_key=_eventorganiser_schedule_start_start&orderby=meta_value">
-<ul class="pagination">
+<div class="terms0408" style="text-align:center; padding: 30px 0 30px 0;">
+<a style="font-size: 20px !important; background: #517fa4; padding: 0.1em 3.0em;" href="https://support.eventz.jp/events/tag/cafekai?order=desc&meta_key=_eventorganiser_schedule_start_start&orderby=meta_value">
 もっと見る
-</ul>
 </a>
+</div>
 
 <div id="Externalseminar">
 <h2><img src="http://support.eventz.jp/wp-content/uploads/2017/05/icon_hoshi02-1.svg">外部セミナー</img></h2>


### PR DESCRIPTION
* トップページのカフェ会の取得件数を50件から30件に減らす(表示速度改善のため)
* もっと見るリンクを追加
* 検索でカスタムフィールドでソートできるようにfunctions.phpを修正